### PR TITLE
Relax dependency upper bounds

### DIFF
--- a/rapid.cabal
+++ b/rapid.cabal
@@ -38,8 +38,8 @@ source-repository head
 
 library
     build-depends:
-        async == 2.1.*,
-        base >= 4.8 && < 4.11,
+        async >= 2.1 && < 2.3,
+        base >= 4.8 && < 4.12,
         containers == 0.5.*,
         foreign-store == 0.2.*,
         stm == 2.4.*


### PR DESCRIPTION
This matches dependencies in lts-12

Here are extracts from relevant changelogs:

- base:
  > 4.11.0.0 March 2018
  >
  >  - Bundled with GHC 8.4.1
  >  - System.IO.openTempFile is now thread-safe on Windows.
  >  - Deprecated GHC.Stats.GCStats interface has been removed.
  >  - Add showHFloat to Numeric
  >  - Add Div, Mod, and Log2 functions on type-level naturals in GHC.TypeLits.
  >  - Add Alternative instance for ZipList (#13520)
  >  - Add instances Num, Functor, Applicative, Monad, Semigroup and Monoid for Data.Ord.Down (#13097).
  >  - Add Semigroup instance for EventLifetime.
  >  - Make Semigroup a superclass of Monoid; export Semigroup((<>)) from Prelude; remove Monoid reexport from Data.Semigroup (#14191).
  >  - Generalise instance Monoid a => Monoid (Maybe a) to instance Semigroup a => Monoid (Maybe a).
  >  - Add infixl 9 !! declaration for Data.List.NonEmpty.!!
  >  - Add <&> operator to Data.Functor (#14029)
  >  - Remove the deprecated Typeable{1..7} type synonyms (#14047)
  >  - Make Data.Type.Equality.== a closed type family. It now works for all kinds out of the box. Any modules that previously declared instances of this family will need to remove them. Whereas the previous definition was somewhat ad hoc, the behavior is now completely uniform. As a result, some applications that used to reduce no longer do, and conversely. Most notably, (==) no longer treats the *, j -> k, or () kinds specially; equality is tested structurally in all cases.
  >  - Add instances Semigroup and Monoid for Control.Monad.ST (#14107).
  >  - The Read instances for Proxy, Coercion, (:~:), (:~~:), and U1 now ignore the parsing precedence. The effect of this is that read will be able to successfully parse more strings containing "Proxy" et al. without surrounding parentheses (e.g., "Thing Proxy") (#12874).
  >  - Add iterate', a strict version of iterate, to Data.List and Data.OldList (#3474)
  >  - Add Data instances for IntPtr and WordPtr (#13115)
  >  - Add missing MonadFail instance for Control.Monad.Strict.ST.ST
  >  - Make zipWith and zipWith3 inlinable (#14224)
  >  - Type.Reflection.App now matches on function types (fixes #14236)
  >  - Type.Reflection.withTypeable is now polymorphic in the RuntimeRep of its result.
  >  - Add installSEHHandlers to MiscFlags in GHC.RTS.Flags to determine if exception handling is enabled.
  >  - The deprecated functions isEmptyChan and unGetChan in Control.Concurrent.Chan have been removed (#13561).
  >  - Add generateCrashDumpFile to MiscFlags in GHC.RTS.Flags to determine if a core dump will be generated on crashes.
  >  - Add generateStackTrace to MiscFlags in GHC.RTS.Flags to determine if stack traces will be generated on unhandled exceptions by the RTS.
  >  - getExecutablePath now resolves symlinks on Windows (#14483)
  >  - Deprecated STM invariant checking primitives (checkInv, always, and alwaysSucceeds) in GHC.Conc.Sync (#14324).
  >  - Add a FixIOException data type to Control.Exception.Base, and change fixIO to throw that instead of a BlockedIndefinitelyOnMVar exception (#14356).

- async:
  > Changes in 2.2:
	>
  > - cancel now throws AsyncCancelled instead of ThreadKilled
  > - link and link2 now wrap exceptions in ExceptionInLinkedThread when throwing to the linked thread. ExceptionInLinkedThread is a child of AsyncException in the exception hierarchy, so this maintains the invariant that exceptions thrown asynchronously should be AsyncExceptions.
  > - link and link2 do not propagate AsyncCancelled, so it's now possible to cancel a linked thread without cancelling yourself.
  > - Added linkOnly and link2Only to specify which exceptions should be propagated,if you want something other than the default behaviour of ignoring AsyncCancelled.
  > - new utility function compareAsyncs for comparing Asyncs of different types.
  > - Add a Hashable instance for Async a